### PR TITLE
MXLookup - Set Default TLS level for the Powershell Session

### DIFF
--- a/MxLookup Module/MxLookup.psm1
+++ b/MxLookup Module/MxLookup.psm1
@@ -25,6 +25,9 @@ Function Connect-MXOnline (){
               $URL = "https://api.mxtoolbox.com/api/v1/usage/"
               
               Write-Verbose $URL
+              
+              Write-Verbose "Enabling TLS1.2 by default for this session"
+              [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
           }
   
       process


### PR DESCRIPTION
MX Toolbox doesn't seem to be allowing connections to the API for anything lower than TLS1.2 by default, this sets the default